### PR TITLE
Add release instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,3 +11,7 @@ Want to install this repo locally?
     - run those instructions in the external consumer (athena)
   - if you get a yarn version >2:
     - in consumer package (ex grafana) `yarn link path-to-sdk` it should add a portal resolution to your package.json
+
+## Creating a Release
+
+Creating a new release requires running the [NPM bump version action](https://github.com/grafana/grafana-async-query-data-js/actions/workflows/npm-bump-version.yml). Click `Run workflow` and specify the type of release (patch, minor, or major). The workflow will update package.json, commit and push which will trigger the [Create Release action](https://github.com/grafana/grafana-async-query-data-js/actions/workflows/create-release.yml) which publishes to npm and creates a github release with release notes.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,3 @@
 # Async Query
 
 This library provides frontend support for handling queries in an asynchronous manner. It requires a backend that can handle asynchronous queries.
-
-## Frontend configuration
-
-see the ./src folder
-
-## Drone configuration
-
-Drone signs the Drone configuration file. This needs to be run everytime the drone.yml file is modified. See https://github.com/grafana/deployment_tools/blob/master/docs/infrastructure/drone/signing.md for more info.
-
-To update the drone file run (note that you need to export your `DRONE_TOKEN` before):
-
-```
-drone --server https://drone.grafana.net sign --save grafana/grafana-async-query-data-js
-```


### PR DESCRIPTION
Add instructions for how to create a release to github and npm.

I've already created an initial release https://www.npmjs.com/package/@grafana/async-query-data. The initial release contains code that was extracted from https://github.com/grafana/grafana-aws-sdk-react/pull/21.