### PR TITLE
Add isQueryValid prop for RunQueryButtons

### DIFF
--- a/src/RunQueryButtons.test.tsx
+++ b/src/RunQueryButtons.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { DataQuery } from '@grafana/data';
+import { RunQueryButtons, RunQueryButtonsProps } from './RunQueryButtons';
+
+const getDefaultProps = (overrides: Partial<RunQueryButtonsProps<DataQuery>>) => {
+  return {
+    onRunQuery: jest.fn(),
+    onCancelQuery: jest.fn(),
+    isQueryValid: jest.fn(),
+    query: { refId: 'refId' },
+    ...overrides,
+  };
+};
+
+describe('RunQueryButtons', () => {
+  it('disable the run button if the query is invalid', () => {
+    const props = getDefaultProps({ isQueryValid: jest.fn().mockReturnValue(false) });
+    render(<RunQueryButtons {...props} />);
+    const runButton = screen.getByRole('button', { name: 'Run' });
+    expect(runButton).toBeDisabled();
+  });
+
+  it('run button should be enabled if the query is valid', () => {
+    const props = getDefaultProps({ isQueryValid: jest.fn().mockReturnValue(true) });
+    render(<RunQueryButtons {...props} />);
+    const runButton = screen.getByRole('button', { name: 'Run' });
+    expect(runButton).not.toBeDisabled();
+  });
+});

--- a/src/RunQueryButtons.tsx
+++ b/src/RunQueryButtons.tsx
@@ -5,6 +5,7 @@ import { DataQuery, LoadingState } from '@grafana/data';
 interface RunQueryButtonsProps<TQuery extends DataQuery> {
   onRunQuery: () => void;
   onCancelQuery: (query: TQuery) => void;
+  isQueryValid: (query: TQuery) => boolean;
   query: TQuery;
   state?: LoadingState;
 }
@@ -36,9 +37,11 @@ export const RunQueryButtons = <TQuery extends DataQuery>(props: RunQueryButtons
     setStopping(true);
   };
 
+  const isQueryValid = props.isQueryValid(props.query);
+
   return (
     <HorizontalGroup>
-      <Button icon={running ? undefined : 'play'} disabled={running} onClick={onRunQuery}>
+      <Button icon={running ? undefined : 'play'} disabled={running || !isQueryValid} onClick={onRunQuery}>
         {running && !stopping ? (
           <HorizontalGroup>
             <Spinner /> Running

--- a/src/RunQueryButtons.tsx
+++ b/src/RunQueryButtons.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { HorizontalGroup, Button, Spinner } from '@grafana/ui';
 import { DataQuery, LoadingState } from '@grafana/data';
 
-interface RunQueryButtonsProps<TQuery extends DataQuery> {
+export interface RunQueryButtonsProps<TQuery extends DataQuery> {
   onRunQuery: () => void;
   onCancelQuery: (query: TQuery) => void;
   isQueryValid: (query: TQuery) => boolean;


### PR DESCRIPTION
Adds a prop `isQueryValid` that allows the parent component to pass in a function that `RunQueryButtons` can use to determine whether a query is valid. If a query is invalid, then the `Run` button will be disabled.

Screenshots of its usage in Redshift query editor
Run button is disabled when query is empty
<img width="1109" alt="Screen Shot 2022-11-30 at 2 17 32 PM" src="https://user-images.githubusercontent.com/19530599/204920360-3221d678-6eaf-4d6f-99ce-ee218ee749fd.png">

Run button is enabled when query is NOT empty
<img width="1109" alt="Screen Shot 2022-11-30 at 2 17 36 PM" src="https://user-images.githubusercontent.com/19530599/204920373-e61e1f86-e3f0-4118-a5b2-2c68ac2e6421.png">
