### PR TITLE
Make onCancelQuery optional

### DIFF
--- a/src/RunQueryButtons.test.tsx
+++ b/src/RunQueryButtons.test.tsx
@@ -28,4 +28,12 @@ describe('RunQueryButtons', () => {
     const runButton = screen.getByRole('button', { name: 'Run' });
     expect(runButton).not.toBeDisabled();
   });
+
+  it('only renders the `Run button if onCancelQuery is undefined', () => {
+    const props = getDefaultProps({ onCancelQuery: undefined });
+    render(<RunQueryButtons {...props} />);
+    const runButton = screen.getByRole('button', { name: 'Run' });
+    expect(runButton).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Stop' })).not.toBeInTheDocument();
+  });
 });

--- a/src/RunQueryButtons.test.tsx
+++ b/src/RunQueryButtons.test.tsx
@@ -4,7 +4,7 @@ import { render, screen } from '@testing-library/react';
 import { DataQuery } from '@grafana/data';
 import { RunQueryButtons, RunQueryButtonsProps } from './RunQueryButtons';
 
-const getDefaultProps = (overrides: Partial<RunQueryButtonsProps<DataQuery>>) => {
+const getDefaultProps = (overrides?: Partial<RunQueryButtonsProps<DataQuery>>) => {
   return {
     onRunQuery: jest.fn(),
     onCancelQuery: jest.fn(),
@@ -29,11 +29,21 @@ describe('RunQueryButtons', () => {
     expect(runButton).not.toBeDisabled();
   });
 
-  it('only renders the `Run button if onCancelQuery is undefined', () => {
+  it('only renders the `Run` button if onCancelQuery is undefined', () => {
     const props = getDefaultProps({ onCancelQuery: undefined });
     render(<RunQueryButtons {...props} />);
     const runButton = screen.getByRole('button', { name: 'Run' });
     expect(runButton).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'Stop' })).not.toBeInTheDocument();
+    const stopButton = screen.queryByRole('button', { name: 'Stop' });
+    expect(stopButton).not.toBeInTheDocument();
+  });
+
+  it('renders the `Run` and `Stop` buttons if onCancelQuery defined', () => {
+    const props = getDefaultProps();
+    render(<RunQueryButtons {...props} />);
+    const runButton = screen.getByRole('button', { name: 'Run' });
+    expect(runButton).toBeInTheDocument();
+    const stopButton = screen.queryByRole('button', { name: 'Stop' });
+    expect(stopButton).toBeInTheDocument();
   });
 });

--- a/src/RunQueryButtons.tsx
+++ b/src/RunQueryButtons.tsx
@@ -4,7 +4,7 @@ import { DataQuery, LoadingState } from '@grafana/data';
 
 export interface RunQueryButtonsProps<TQuery extends DataQuery> {
   onRunQuery: () => void;
-  onCancelQuery: (query: TQuery) => void;
+  onCancelQuery?: (query: TQuery) => void;
   isQueryValid: (query: TQuery) => boolean;
   query: TQuery;
   state?: LoadingState;
@@ -32,10 +32,12 @@ export const RunQueryButtons = <TQuery extends DataQuery>(props: RunQueryButtons
     props.onRunQuery();
   };
 
-  const onCancelQuery = () => {
-    props.onCancelQuery(lastQuery);
-    setStopping(true);
-  };
+  const onCancelQuery = props.onCancelQuery
+    ? () => {
+        props.onCancelQuery?.(lastQuery);
+        setStopping(true);
+      }
+    : undefined;
 
   const isQueryValid = props.isQueryValid(props.query);
 
@@ -50,15 +52,17 @@ export const RunQueryButtons = <TQuery extends DataQuery>(props: RunQueryButtons
           'Run'
         )}
       </Button>
-      <Button icon={running ? undefined : 'square-shape'} disabled={!running || stopping} onClick={onCancelQuery}>
-        {stopping ? (
-          <HorizontalGroup>
-            <Spinner /> Stopping
-          </HorizontalGroup>
-        ) : (
-          'Stop'
-        )}
-      </Button>
+      {onCancelQuery && (
+        <Button icon={running ? undefined : 'square-shape'} disabled={!running || stopping} onClick={onCancelQuery}>
+          {stopping ? (
+            <HorizontalGroup>
+              <Spinner /> Stopping
+            </HorizontalGroup>
+          ) : (
+            'Stop'
+          )}
+        </Button>
+      )}
     </HorizontalGroup>
   );
 };


### PR DESCRIPTION
Fixes: #4 

Makes the onCancelQuery prop optional. If it's not passed in, the stop button is not rendered.

With onCancelQuery provided
<img width="228" alt="Screen Shot 2022-12-05 at 8 29 43 AM" src="https://user-images.githubusercontent.com/19530599/205690303-ff1e8132-f1ab-4a68-b975-52c5d7e362c5.png">

With onCancelQuery undefined
<img width="228" alt="Screen Shot 2022-12-05 at 8 31 08 AM" src="https://user-images.githubusercontent.com/19530599/205690393-2cab18b6-80d6-45cd-b9ac-d597a168d06c.png">
