### PR TITLE
Add missing test

### DIFF
--- a/src/RunQueryButtons.test.tsx
+++ b/src/RunQueryButtons.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 
 import { DataQuery } from '@grafana/data';
 import { RunQueryButtons, RunQueryButtonsProps } from './RunQueryButtons';
@@ -45,5 +45,16 @@ describe('RunQueryButtons', () => {
     expect(runButton).toBeInTheDocument();
     const stopButton = screen.queryByRole('button', { name: 'Stop query' });
     expect(stopButton).toBeInTheDocument();
+  });
+
+  it('Stop query button should be disabled until run button is clicked', () => {
+    const props = getDefaultProps();
+    render(<RunQueryButtons {...props} />);
+    const runButton = screen.getByRole('button', { name: 'Run query' });
+    const stopButton = screen.getByRole('button', { name: 'Stop query' });
+    expect(stopButton).toBeInTheDocument();
+    expect(stopButton).toBeDisabled();
+    fireEvent.click(runButton);
+    expect(stopButton).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
Realized this test should probably be moved from [here](https://github.com/grafana/athena-datasource/blob/3b0518bf118910644c84082c03d222862f83133d/src/QueryEditor.test.tsx#L188) to this repo, since the component structure changed a bit and now this component (RunQueryButtons) is the main one in charge of disabling and enabling async buttons. 