### PR TITLE
Add error catch to results of backend response

### DIFF
--- a/src/DatasourceWithAsyncBackend.ts
+++ b/src/DatasourceWithAsyncBackend.ts
@@ -8,7 +8,7 @@ import {
 } from '@grafana/data';
 import { BackendDataSourceResponse, DataSourceWithBackend, getBackendSrv, toDataQueryResponse } from '@grafana/runtime';
 import { merge, Observable, of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { catchError,map } from 'rxjs/operators';
 import { getRequestLooper } from './requestLooper';
 
 export interface CustomMeta {
@@ -151,7 +151,9 @@ export class DatasourceWithAsyncBackend<
 
           return getBackendSrv()
             .fetch<BackendDataSourceResponse>(options)
-            .pipe(map((result) => ({ data: toDataQueryResponse(result).data })));
+            .pipe(map((result) => ({ data: toDataQueryResponse(result).data })), catchError((err) => {
+              return of(toDataQueryResponse(err));
+            }));
         },
 
         /**


### PR DESCRIPTION
**Why do we need this feature?**
In the context of the [reported issue](https://github.com/grafana/redshift-datasource/issues/209), with `redshiftAsyncQueryDataSupport` = false, the error runs through:   https://github.com/grafana/grafana/blob/9e1ea8c990d4d52d3db518ec6e3e75422730be3a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts#L231

This PR provides the same error handling in order to trigger the same error display.

**Which issue(s) does this PR fix?**:
Contributes to https://github.com/grafana/redshift-datasource/issues/209
Need to release this in a bumped version, bump the async-query-data versions in Redshift (and Athena) and release Redshift (and Athena) to fix the reported issue. 

**Special notes for your reviewer**:
Local testing:
1. In OSS Grafana repo, reproduce the original issue with the following in custom.ini
```
[feature_toggles]
redshiftAsyncQueryDataSupport = true
```
2. In Redshift repo's package.json, bump the version of the `"@grafana/async-query-data"` in the `dependencies` object to `"0.1.4",`
It should read:
```
  "dependencies": {
    "@grafana/async-query-data": "0.1.4",
    "@grafana/experimental": "^0.0.2-canary.39"
  },
```
(This step is not strictly required but has unified the version of `async-query-data` in Redshift and made the following step easier to manage. This version will be bumped again in Redshift and Athena after this PR is merged, so I don't think it's a big deal to do this locally for testing purposes...)

3. In this repo `grafana-async-query-data-js`, pull these changes. `yarn build`
4. In Redshift repo, delete any `dist` and `node_modules` to start from a clean state. Build the backend with`mage`. For the frontend, `yarn install` first. Copy the `dist` from `grafana-async-query-data-js` repo and replace the `dist` in the `node_modules` in Redshift repo.

![Screenshot 2023-03-07 at 10 53 00](https://user-images.githubusercontent.com/4163034/223387164-a2c3c7e5-0f1a-457d-b430-f2bc1af053c1.png)

5. In Redshift repo, complete the frontend build with `yarn dev` or `yarn build`.
6. In OSS Grafana, build the frontend (yarn install, yarn start) and start backend server (make run)
7. In your browser, reproduce the original issue. This is what it should look like with the changes from this PR:
![Screenshot 2023-03-07 at 10 56 37](https://user-images.githubusercontent.com/4163034/223387904-a362d1dc-5999-4cdc-9355-737204d7defd.png)

Huge thanks to @kevinwcyu for all the help in finding this one