### PR TITLE
Fix yarn dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Async query support for Grafana",
   "main": "dist/index.js",
   "scripts": {
-    "dev": "watch 'npm run bundle' ./src",
+    "dev": "yarn bundle --watch --watch.onStart=\"yarn typecheck\"",
     "build": "yarn clean && yarn typecheck && yarn bundle",
     "bundle": "rollup -c rollup.config.ts",
     "clean": "rimraf ./dist ./compiled",

--- a/rollup.config.ts
+++ b/rollup.config.ts
@@ -39,5 +39,8 @@ export default [
       file: pkg.publishConfig.types,
       format: 'es',
     },
+    watch: {
+      exclude: './compiled/**',
+    },
   },
 ];


### PR DESCRIPTION
- add `--watch` flag for rollup
- add `--watch.onStart=\"yarn typecheck\"` to ensure ./compiled types are available when running `yarn dev`. Previously a clean repo would throw an error unless `yarn typecheck` was not run before `yarn dev`
