### PR TITLE
Update npm-bump-version.yml secret name

### DIFF
--- a/.github/workflows/npm-bump-version.yml
+++ b/.github/workflows/npm-bump-version.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GH_BOT_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup environment
         uses: actions/setup-node@v2.5.1


### PR DESCRIPTION
I think we just need to switch out the name of the secret, as described in the 1st section [here](https://github.com/grafana/deployment_tools/blob/master/docs/interacting-with-github-api.md) if I understand correctly? 

If this doesn't work we can switch to Apps but wanted to try this first

`For Actions, you should almost never have to use an external token. Actions expose a token in the ${{ secrets.GITHUB_TOKEN }} environment variable. This token is automatically generated by GitHub and has permissions for the repository it is running in.`

Edit: Failed to give context for this one: [This is the ticket](https://github.com/grafana/redshift-datasource/issues/209) that reports the problem. npm-bump-version workflow for this package [fails](https://github.com/grafana/grafana-async-query-data-js/actions/runs/4479898061/jobs/7874469920#step:2:50) with `Error: fatal: could not read Username for 'https://github.com/': terminal prompts disabled`, which points to a problem with authorization with tokens.  