### PR TITLE
prepare 0.1.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.1.7
+
+- Don't set cache-skip header if async caching enabled (#17)
+
 ## v0.1.5
 
 - Update npm-bump-version.yml (#15)


### PR DESCRIPTION
Release the skip-cache header change. (In retrospect I should have bumped the version in the pr)