### PR TITLE
Use version fro package json to generate tag_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,6 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
-              tag_name: "${{ github.ref }}",
+              tag_name: "v${{ steps.version_check.outputs.version }}",
               generate_release_notes: true
             });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
+## v0.1.8
+
+- Update github release workflow (#20)
 
 ## v0.1.7
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/async-query-data",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Async query support for Grafana",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
We have a [broken workflow](https://github.com/grafana/grafana-async-query-data-js/commit/3acf8d58321c8c55e579ebe3f4005f2003444b18) caused by github.ref being always the same. I don't think this ever worked (at least not recently). 
This uses the [output](https://github.com/EndBug/version-check#outputs) from the previous step (npm-publish) to get the tag name and prefixes it with "v".

