### PR TITLE
Prefix requestId with data source id

### DIFF
--- a/src/DatasourceWithAsyncBackend.test.ts
+++ b/src/DatasourceWithAsyncBackend.test.ts
@@ -1,6 +1,13 @@
-import { DataQuery, DataSourceInstanceSettings, PluginType, getDefaultTimeRange } from '@grafana/data';
+import {
+  DataQuery,
+  DataQueryRequest,
+  DataSourceInstanceSettings,
+  PluginType,
+  getDefaultTimeRange,
+} from '@grafana/data';
 import { DataSourceWithBackend } from '@grafana/runtime';
 import { DatasourceWithAsyncBackend } from './DatasourceWithAsyncBackend';
+import { RequestLoopOptions } from 'requestLooper';
 
 const queryMock = jest.fn().mockImplementation(() => Promise.resolve({ data: [] }));
 jest.spyOn(DataSourceWithBackend.prototype, 'query').mockImplementation(queryMock);
@@ -8,7 +15,7 @@ jest.spyOn(DataSourceWithBackend.prototype, 'query').mockImplementation(queryMoc
 const getRequestLooperMock = jest.fn();
 jest.mock('./requestLooper.ts', () => ({
   ...jest.requireActual('./requestLooper.ts'),
-  getRequestLooper: (req: any, options: any) => getRequestLooperMock(req, options),
+  getRequestLooper: (req: DataQueryRequest, options: RequestLoopOptions) => getRequestLooperMock(req, options),
 }));
 
 const defaultInstanceSettings: DataSourceInstanceSettings<{}> = {

--- a/src/requestLooper.test.ts
+++ b/src/requestLooper.test.ts
@@ -106,7 +106,7 @@ describe('requestLooper', () => {
         .mockImplementationOnce(() => ({ ...mockQuery, queryId: 'queryId' }))
         .mockImplementationOnce(() => ({ ...mockQuery, queryId: 'queryId' }))
         .mockImplementationOnce(() => undefined),
-      query: (req: any) => queryMock(req),
+      query: (req) => queryMock(req),
       onCancel: jest.fn(),
       process: jest.fn().mockImplementation(() => []),
       shouldCancel: jest.fn().mockImplementation(() => false),

--- a/src/requestLooper.test.ts
+++ b/src/requestLooper.test.ts
@@ -1,6 +1,7 @@
 import { RequestLoopOptions, getRequestLooper } from 'requestLooper';
 import { TestScheduler } from 'rxjs/testing';
-import { getDefaultTimeRange, DataQuery, LoadingState } from '@grafana/data';
+import { of } from 'rxjs';
+import { getDefaultTimeRange, DataQuery, LoadingState, DataQueryRequest } from '@grafana/data';
 
 const mockQuery: DataQuery = {
   refId: '',
@@ -89,5 +90,39 @@ describe('requestLooper', () => {
 
     scheduler.flush();
     expect(onCancel).toBeCalledTimes(1);
+  });
+
+  it('increments the request id', (done) => {
+    let requestIds: string[] = [];
+
+    const queryMock = jest.fn().mockImplementation((req: DataQueryRequest) => {
+      requestIds.push(req.requestId);
+      return of({ data: [], state: LoadingState.Loading, meta });
+    });
+
+    const opt: RequestLoopOptions = {
+      getNextQuery: jest
+        .fn()
+        .mockImplementationOnce(() => ({ ...mockQuery, queryId: 'queryId' }))
+        .mockImplementationOnce(() => ({ ...mockQuery, queryId: 'queryId' }))
+        .mockImplementationOnce(() => undefined),
+      query: (req: any) => queryMock(req),
+      onCancel: jest.fn(),
+      process: jest.fn().mockImplementation(() => []),
+      shouldCancel: jest.fn().mockImplementation(() => false),
+    };
+
+    const looper = getRequestLooper(request, opt);
+
+    looper.subscribe({
+      next: () => {},
+      complete: () => {
+        expect(requestIds).toHaveLength(3);
+        expect(requestIds[0]).toBe(request.requestId);
+        expect(requestIds[1]).toBe(request.requestId + '.2');
+        expect(requestIds[2]).toBe(request.requestId + '.3');
+        done();
+      },
+    });
   });
 });


### PR DESCRIPTION
Because different async datasources were creating queries with the same prefix, they were creating overlapping requestIds where every query but the last one was getting canceled by `backendSrv`. Also because the requestID code had been taken from timestream, they were overlapping with timestream query request ids.  This changes the code to use the datasource id as the prefix, which should be unique.

Part of https://github.com/grafana/timestream-datasource/issues/273