### PR TITLE
Use super.query

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "author": "Grafana Labs <team@grafana.com> (https://grafana.com)",
   "license": "Apache-2.0",
   "dependencies": {
+    "semver": "^7.6.3",
     "tslib": "^2.8.0"
   },
   "devDependencies": {
@@ -45,6 +46,7 @@
     "@types/jest": "29.5.14",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
+    "@types/semver": "^7.5.8",
     "@typescript-eslint/eslint-plugin": "^8.12.0",
     "@typescript-eslint/parser": "^8.12.0",
     "esbuild": "^0.24.0",

--- a/src/DatasourceWithAsyncBackend.test.ts
+++ b/src/DatasourceWithAsyncBackend.test.ts
@@ -105,7 +105,7 @@ describe('DatasourceWithAsyncBackend', () => {
     expect(ds.doSingle).toHaveBeenCalledWith(defaultQuery2, defaultRequest);
   });
 
-  it('uses the datasource id for the request id', () => {
+  it('uses the datasource uid for the request uid', () => {
     const ds = setupDatasourceWithAsyncBackend();
     expect(getRequestLooperMock).not.toHaveBeenCalled();
     ds.doSingle(defaultQuery, defaultRequest);
@@ -113,7 +113,7 @@ describe('DatasourceWithAsyncBackend', () => {
     const expectedRequest = {
       ...defaultRequest,
       targets: [defaultQuery],
-      requestId: '12_100',
+      requestId: 'test_100',
     };
     expect(getRequestLooperMock).toHaveBeenCalledWith(expectedRequest, expect.anything());
   });

--- a/src/DatasourceWithAsyncBackend.ts
+++ b/src/DatasourceWithAsyncBackend.ts
@@ -18,8 +18,6 @@ import { catchError, map } from 'rxjs/operators';
 import { gte } from 'semver';
 import { getRequestLooper } from './requestLooper';
 
-const requestSupportsSkipQueryCache = gte(config.buildInfo.version, '10.2.3');
-
 export interface CustomMeta {
   queryID: string;
   status: string;
@@ -133,6 +131,7 @@ export class DatasourceWithAsyncBackend<
           // The caching service handles bypassing the query cache automatically when it is enabled.
           const cachingDisabled = !config.featureToggles.awsAsyncQueryCaching;
           if (cachingDisabled && isRunning(status)) {
+            const requestSupportsSkipQueryCache = gte(config.buildInfo.version, '10.2.3');
             if (!requestSupportsSkipQueryCache) {
               return getBackendSrv()
                 .fetch<BackendDataSourceResponse>({

--- a/src/DatasourceWithAsyncBackend.ts
+++ b/src/DatasourceWithAsyncBackend.ts
@@ -15,7 +15,7 @@ import {
 } from '@grafana/runtime';
 import { merge, Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
-import { gte } from 'semver';
+import { lt } from 'semver';
 import { getRequestLooper } from './requestLooper';
 
 export interface CustomMeta {
@@ -131,8 +131,8 @@ export class DatasourceWithAsyncBackend<
           // The caching service handles bypassing the query cache automatically when it is enabled.
           const cachingDisabled = !config.featureToggles.awsAsyncQueryCaching;
           if (cachingDisabled && isRunning(status)) {
-            const requestSupportsSkipQueryCache = gte(config.buildInfo.version, '10.2.3');
-            if (!requestSupportsSkipQueryCache) {
+            const requestSkipQueryCacheUnsupported = lt(config.buildInfo.version, '10.2.3');
+            if (requestSkipQueryCacheUnsupported) {
               return getBackendSrv()
                 .fetch<BackendDataSourceResponse>({
                   method: 'POST',

--- a/src/DatasourceWithAsyncBackend.ts
+++ b/src/DatasourceWithAsyncBackend.ts
@@ -15,7 +15,10 @@ import {
 } from '@grafana/runtime';
 import { merge, Observable, of } from 'rxjs';
 import { catchError, map } from 'rxjs/operators';
+import { gte } from 'semver';
 import { getRequestLooper } from './requestLooper';
+
+const requestSupportsSkipQueryCache = gte(config.buildInfo.version, '10.2.3');
 
 export interface CustomMeta {
   queryID: string;
@@ -39,15 +42,15 @@ const isCustomMeta = (meta: unknown): meta is CustomMeta => {
 
 export class DatasourceWithAsyncBackend<
   TQuery extends DataQuery = DataQuery,
-  TOptions extends DataSourceJsonData = DataSourceJsonData,
+  TOptions extends DataSourceJsonData = DataSourceJsonData
 > extends DataSourceWithBackend<TQuery, TOptions> {
   private runningQueries: { [hash: string]: RunningQueryInfo } = {};
   private requestCounter = 100;
-  private requestIdPrefix: number;
+  private requestIdPrefix: number | string;
 
   constructor(instanceSettings: DataSourceInstanceSettings<TOptions>) {
     super(instanceSettings);
-    this.requestIdPrefix = instanceSettings.id;
+    this.requestIdPrefix = instanceSettings.uid ?? instanceSettings.id;
   }
 
   query(request: DataQueryRequest<TQuery>): Observable<DataQueryResponse> {
@@ -118,48 +121,42 @@ export class DatasourceWithAsyncBackend<
           const query: TQuery & DataQueryMeta = {
             ..._query,
             meta: { queryFlow: 'async' },
+            intervalMs,
+            maxDataPoints,
+            // getRef optionally chained to support < v8.3.x of Grafana
+            datasource: this?.getRef(),
+            datasourceId: this.id,
+            ...this.applyTemplateVariables(_query, request.scopedVars),
           };
 
-          const data = {
-            queries: [
-              {
-                ...query,
-                intervalMs,
-                maxDataPoints,
-                // getRef optionally chained to support < v8.3.x of Grafana
-                datasource: this?.getRef(),
-                datasourceId: this.id,
-                ...this.applyTemplateVariables(query, request.scopedVars),
-              },
-            ],
-            range: range,
-            from: range.from.valueOf().toString(),
-            to: range.to.valueOf().toString(),
-          };
-
-          let headers = {};
+          // Manually bypass the query cache for running queries if the caching service is not enabled.
+          // The caching service handles bypassing the query cache automatically when it is enabled.
           const cachingDisabled = !config.featureToggles.awsAsyncQueryCaching;
           if (cachingDisabled && isRunning(status)) {
-            // bypass query caching for Grafana Enterprise to
-            // prevent an infinite loop
-            headers = { 'X-Cache-Skip': true };
-          }
-          const options = {
-            method: 'POST',
-            url: '/api/ds/query',
-            data,
-            requestId,
-            headers,
-          };
+            if (!requestSupportsSkipQueryCache) {
+              return getBackendSrv()
+                .fetch<BackendDataSourceResponse>({
+                  method: 'POST',
+                  url: '/api/ds/query',
+                  headers: { 'X-Cache-Skip': true },
+                  requestId,
+                  data: {
+                    queries: [query],
+                    range: range,
+                    from: range.from.valueOf().toString(),
+                    to: range.to.valueOf().toString(),
+                  },
+                })
+                .pipe(
+                  map((result) => ({ data: toDataQueryResponse(result).data })),
+                  catchError((err) => of(toDataQueryResponse(err)))
+                );
+            }
 
-          return getBackendSrv()
-            .fetch<BackendDataSourceResponse>(options)
-            .pipe(
-              map((result) => ({ data: toDataQueryResponse(result).data })),
-              catchError((err) => {
-                return of(toDataQueryResponse(err));
-              })
-            );
+            return super.query({ ...request, targets: [query], skipQueryCache: true });
+          }
+
+          return super.query({ ...request, targets: [query] });
         },
 
         /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -409,7 +409,14 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
-"@babel/runtime@^7.12.1", "@babel/runtime@^7.18.0", "@babel/runtime@^7.23.2", "@babel/runtime@^7.23.9", "@babel/runtime@^7.24.1", "@babel/runtime@^7.24.5", "@babel/runtime@^7.7.6":
+"@babel/runtime@^7.12.1", "@babel/runtime@^7.18.0", "@babel/runtime@^7.23.2":
+  version "7.24.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.0.tgz#584c450063ffda59697021430cb47101b085951e"
+  integrity sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.23.9", "@babel/runtime@^7.24.1", "@babel/runtime@^7.24.5", "@babel/runtime@^7.7.6":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.25.9.tgz#65884fd6dc255a775402cc1d9811082918f4bf00"
   integrity sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==
@@ -2101,9 +2108,9 @@
   integrity sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==
 
 "@swc/helpers@^0.5.0":
-  version "0.5.13"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.13.tgz#33e63ff3cd0cade557672bd7888a39ce7d115a8c"
-  integrity sha512-UoKGxQ3r5kYI9dALKJapMmuK+1zWM/H17Z1+iwnNmzcJRnfFuevZs375TA5rW31pu4BS4NoSy1fRsexDXfWn5w==
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.6.tgz#d16d8566b7aea2bef90d059757e2d77f48224160"
+  integrity sha512-aYX01Ke9hunpoCexYAgQucEpARGQ5w/cqHFrIR+e9gdKb1QWTsVJuTJ2ozQzIAxLyRQe/m+2RqzkyOOGiMKRQA==
   dependencies:
     tslib "^2.4.0"
 
@@ -2374,6 +2381,11 @@
   version "0.16.2"
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
+
+"@types/semver@^7.5.8":
+  version "7.5.8"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
+  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
 
 "@types/sizzle@*":
   version "2.3.9"
@@ -2998,9 +3010,9 @@ cliui@^8.0.1:
     wrap-ansi "^7.0.0"
 
 clsx@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.1.tgz#eed397c9fd8bd882bfb18deab7102049a2f32999"
-  integrity sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/clsx/-/clsx-2.1.0.tgz#e851283bcb5c80ee7608db18487433f7b23f77cb"
+  integrity sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==
 
 co@^4.6.0:
   version "4.6.0"
@@ -3305,9 +3317,9 @@ d3-force@3:
   integrity sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==
 
 d3-geo@3:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.1.tgz#6027cf51246f9b2ebd64f99e01dc7c3364033a4d"
-  integrity sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-3.1.0.tgz#74fd54e1f4cebd5185ac2039217a98d39b0a4c0e"
+  integrity sha512-JEo5HxXDdDYXCaWdwLRt79y7giK8SbhZJbFWXqbRTolCHFI5jRqteLzCsq51NKbUoX0PjBVSohxrx+NoOUujYA==
   dependencies:
     d3-array "2.5.0 - 3"
 
@@ -3344,9 +3356,9 @@ d3-random@3:
   integrity sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
 
 d3-scale-chromatic@3:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz#34c39da298b23c20e02f1a4b239bd0f22e7f1314"
-  integrity sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz#15b4ceb8ca2bb0dcb6d1a641ee03d59c3b62376a"
+  integrity sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==
   dependencies:
     d3-color "1 - 3"
     d3-interpolate "1 - 3"
@@ -4696,9 +4708,9 @@ hyphenate-style-name@^1.0.3:
   integrity sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ==
 
 i18next-browser-languagedetector@^7.0.2:
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.1.tgz#1968196d437b4c8db847410c7c33554f6c448f6f"
-  integrity sha512-h/pM34bcH6tbz8WgGXcmWauNpQupCGr25XPp9cZwZInR9XHSjIFDYp1SIok7zSPsTOMxdvuLyu86V+g2Kycnfw==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-7.2.0.tgz#de0321cba6881be37d82e20e4d6f05aa75f6e37f"
+  integrity sha512-U00DbDtFIYD3wkWsr2aVGfXGAj2TgnELzOX9qv8bT0aJtvPV9CRO77h+vgmHFBMe7LAxdwvT/7VkCWGya6L3tA==
   dependencies:
     "@babel/runtime" "^7.23.2"
 
@@ -6589,13 +6601,13 @@ rc-motion@^2.0.0, rc-motion@^2.0.1:
     rc-util "^5.21.0"
 
 rc-motion@^2.6.1:
-  version "2.9.3"
-  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.9.3.tgz#b1bdaf816f1ccb3e4b3b0c531c3037a59286379e"
-  integrity sha512-rkW47ABVkic7WEB0EKJqzySpvDqwl60/tdkY7hWP7dYnh5pm0SzJpo54oW3TDUGXV5wfxXFmMkxrzRRbotQ0+w==
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/rc-motion/-/rc-motion-2.9.0.tgz#9e18a1b8d61e528a97369cf9a7601e9b29205710"
+  integrity sha512-XIU2+xLkdIr1/h6ohPZXyPBMvOmuyFZQ/T0xnawz+Rh+gh4FINcnZmMT5UTIj6hgI0VLDjTaPeRd+smJeSPqiQ==
   dependencies:
     "@babel/runtime" "^7.11.1"
     classnames "^2.2.1"
-    rc-util "^5.43.0"
+    rc-util "^5.21.0"
 
 rc-overflow@^1.3.1:
   version "1.3.2"
@@ -6713,7 +6725,15 @@ rc-util@^5.16.1, rc-util@^5.21.0, rc-util@^5.27.0:
     "@babel/runtime" "^7.18.3"
     react-is "^16.12.0"
 
-rc-util@^5.24.4, rc-util@^5.36.0, rc-util@^5.37.0, rc-util@^5.38.0, rc-util@^5.38.1, rc-util@^5.43.0:
+rc-util@^5.24.4, rc-util@^5.36.0, rc-util@^5.37.0, rc-util@^5.38.0:
+  version "5.38.2"
+  resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.38.2.tgz#240da546b51ee838e616f7a2e3fcf62c753b0330"
+  integrity sha512-yRGRPKyi84H7NkRSP6FzEIYBdUt4ufdsmXUZ7qM2H5qoByPax70NnGPkfo36N+UKUnUBj2f2Q2eUbwYMuAsIOQ==
+  dependencies:
+    "@babel/runtime" "^7.18.3"
+    react-is "^18.2.0"
+
+rc-util@^5.38.1:
   version "5.43.0"
   resolved "https://registry.yarnpkg.com/rc-util/-/rc-util-5.43.0.tgz#bba91fbef2c3e30ea2c236893746f3e9b05ecc4c"
   integrity sha512-AzC7KKOXFqAdIBqdGWepL9Xn7cm3vnAmjlHqUnoQaTMZYhM4VlXGLkkHHxj/BZ7Td0+SOPKB4RGPboBVKT9htw==
@@ -6722,9 +6742,9 @@ rc-util@^5.24.4, rc-util@^5.36.0, rc-util@^5.37.0, rc-util@^5.38.0, rc-util@^5.3
     react-is "^18.2.0"
 
 rc-virtual-list@^3.5.1, rc-virtual-list@^3.5.2:
-  version "3.14.8"
-  resolved "https://registry.yarnpkg.com/rc-virtual-list/-/rc-virtual-list-3.14.8.tgz#abf6e8809b7f5c955aa7f59c2a9d57443e9942fd"
-  integrity sha512-8D0KfzpRYi6YZvlOWIxiOm9BGt4Wf2hQyEaM6RXlDDiY2NhLheuYI+RA+7ZaZj1lq+XQqy3KHlaeeXQfzI5fGg==
+  version "3.11.4"
+  resolved "https://registry.yarnpkg.com/rc-virtual-list/-/rc-virtual-list-3.11.4.tgz#d0a8937843160b7b00d5586854290bf56d396af7"
+  integrity sha512-NbBi0fvyIu26gP69nQBiWgUMTPX3mr4FcuBQiVqagU0BnuX8WQkiivnMs105JROeuUIFczLrlgUhLQwTWV1XDA==
   dependencies:
     "@babel/runtime" "^7.20.0"
     classnames "^2.2.6"
@@ -6821,7 +6841,7 @@ react-inlinesvg@3.0.2:
     exenv "^1.2.2"
     react-from-dom "^0.6.2"
 
-react-is@18.2.0, react-is@^18.0.0:
+react-is@18.2.0, react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
@@ -6835,11 +6855,6 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
-
-react-is@^18.2.0:
-  version "18.3.1"
-  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.3.1.tgz#e83557dc12eae63a99e003a46388b1dcbb44db7e"
-  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -7267,7 +7282,7 @@ semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.5.3, semver@^7.6.0, semver@^7.6.3:
+semver@^7.5.3, semver@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
   integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
@@ -7276,6 +7291,13 @@ semver@^7.5.4:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
   integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -7876,7 +7898,12 @@ tslib@2.7.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
-tslib@^2.1.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.0:
+tslib@^2.1.0, tslib@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
+
+tslib@^2.6.2, tslib@^2.8.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
Makes query requests with `super.query`. The `DataSourceWithBackend` query method provides functionality to support public dashboards.

Tested by linking this package with `yarn link` and then running `yarn link "@grafana/async-query-data"` in athena and redshift. You can create a dashboard with an athena panel and redshift panel, saving the dashboard, then sharing it externally. The link can be opened in an incognito window to see that you can see the results of the dashboard.