### PR TITLE
asyncQueryDataSupport: always run queries asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.2.0
+
+- Remove athenaAsyncQueryDataSupport and redshiftAsyncQueryData feature toggle-related code
+
 ## v0.1.11
 
 - Support Node 18 (#25)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grafana/async-query-data",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "description": "Async query support for Grafana",
   "main": "dist/index.js",
   "scripts": {

--- a/src/DatasourceWithAsyncBackend.test.ts
+++ b/src/DatasourceWithAsyncBackend.test.ts
@@ -62,13 +62,8 @@ const defaultRequest = {
   startTime: 0,
 };
 
-const setupDatasourceWithAsyncBackend = ({
-  settings = defaultInstanceSettings,
-  asyncQueryDataSupport = true,
-}: {
-  settings?: DataSourceInstanceSettings<{}>;
-  asyncQueryDataSupport?: boolean;
-}) => new DatasourceWithAsyncBackend<DataQuery>(settings, asyncQueryDataSupport);
+const setupDatasourceWithAsyncBackend = (settings: DataSourceInstanceSettings = defaultInstanceSettings) =>
+  new DatasourceWithAsyncBackend<DataQuery>(settings);
 
 describe('DatasourceWithAsyncBackend', () => {
   // beforeAll(() => {
@@ -76,14 +71,14 @@ describe('DatasourceWithAsyncBackend', () => {
   // });
 
   it('can store running queries', () => {
-    const ds = setupDatasourceWithAsyncBackend({});
+    const ds = setupDatasourceWithAsyncBackend();
 
     ds.storeQuery(defaultQuery, { queryID: '123' });
     expect(ds.getQuery(defaultQuery)).toEqual({ queryID: '123' });
   });
 
   it('can remove running queries', () => {
-    const ds = setupDatasourceWithAsyncBackend({});
+    const ds = setupDatasourceWithAsyncBackend();
 
     ds.storeQuery(defaultQuery, { queryID: '123' });
     expect(ds.getQuery(defaultQuery)).toEqual({ queryID: '123' });
@@ -92,15 +87,15 @@ describe('DatasourceWithAsyncBackend', () => {
   });
 
   it('can cancel running queries', () => {
-    const ds = setupDatasourceWithAsyncBackend({});
+    const ds = setupDatasourceWithAsyncBackend();
 
     ds.storeQuery(defaultQuery, { queryID: '123' });
     ds.cancel(defaultQuery);
     expect(ds.getQuery(defaultQuery)).toEqual({ queryID: '123', shouldCancel: true });
   });
 
-  it('can queue individual queries to run asynchronously if feature toggle asyncQueryDataSupport is `true`', () => {
-    const ds = setupDatasourceWithAsyncBackend({ asyncQueryDataSupport: true });
+  it('will queue individual queries to run asynchronously', () => {
+    const ds = setupDatasourceWithAsyncBackend();
 
     ds.doSingle = jest.fn().mockReturnValue(Promise.resolve({ data: [] }));
     expect(ds.doSingle).not.toHaveBeenCalled();
@@ -110,19 +105,8 @@ describe('DatasourceWithAsyncBackend', () => {
     expect(ds.doSingle).toHaveBeenCalledWith(defaultQuery2, defaultRequest);
   });
 
-  it('can run queries synchronously if feature toggle asyncQueryDataSupport is `false`', () => {
-    const ds = setupDatasourceWithAsyncBackend({ asyncQueryDataSupport: false });
-
-    ds.doSingle = jest.fn();
-    expect(ds.doSingle).not.toHaveBeenCalled();
-    ds.query(defaultRequest);
-    expect(ds.doSingle).not.toHaveBeenCalled();
-    expect(queryMock).toHaveBeenCalledTimes(1);
-    expect(queryMock).toHaveBeenCalledWith(defaultRequest);
-  });
-
   it('uses the datasource id for the request id', () => {
-    const ds = setupDatasourceWithAsyncBackend({ asyncQueryDataSupport: true });
+    const ds = setupDatasourceWithAsyncBackend();
     expect(getRequestLooperMock).not.toHaveBeenCalled();
     ds.doSingle(defaultQuery, defaultRequest);
     expect(getRequestLooperMock).toHaveBeenCalledTimes(1);

--- a/src/RunQueryButtons.test.tsx
+++ b/src/RunQueryButtons.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {fireEvent, render, screen} from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { DataQuery } from '@grafana/data';
 import { RunQueryButtons, RunQueryButtonsProps } from './RunQueryButtons';
@@ -15,36 +15,27 @@ const getDefaultProps = (overrides?: Partial<RunQueryButtonsProps<DataQuery>>) =
 };
 
 describe('RunQueryButtons', () => {
-  it('disable the run button if the if the enableRun button is false', () => {
-    const props = getDefaultProps({ enableRun: false});
-    render(<RunQueryButtons {...props} />);
-    const runButton = screen.getByRole('button', { name: 'Run query' });
-    expect(runButton).toBeDisabled();
-  });
-
-  it('run button should be enabled if the enableRun button is true', () => {
-    const props = getDefaultProps({ enableRun: true});
-    render(<RunQueryButtons {...props} />);
-    const runButton = screen.getByRole('button', { name: 'Run query' });
-    expect(runButton).not.toBeDisabled();
-  });
-
-  it('only renders the `Run` button if onCancelQuery is undefined', () => {
-    const props = getDefaultProps({ onCancelQuery: undefined });
-    render(<RunQueryButtons {...props} />);
-    const runButton = screen.getByRole('button', { name: 'Run query' });
-    expect(runButton).toBeInTheDocument();
-    const stopButton = screen.queryByRole('button', { name: 'Stop query' });
-    expect(stopButton).not.toBeInTheDocument();
-  });
-
-  it('renders the `Run` and `Stop` buttons if onCancelQuery defined', () => {
+  it('renders the `Run` and `Stop` buttons', () => {
     const props = getDefaultProps();
     render(<RunQueryButtons {...props} />);
     const runButton = screen.getByRole('button', { name: 'Run query' });
     expect(runButton).toBeInTheDocument();
     const stopButton = screen.queryByRole('button', { name: 'Stop query' });
     expect(stopButton).toBeInTheDocument();
+  });
+  
+  it('disable the run button if the if the enableRun button is false', () => {
+    const props = getDefaultProps({ enableRun: false });
+    render(<RunQueryButtons {...props} />);
+    const runButton = screen.getByRole('button', { name: 'Run query' });
+    expect(runButton).toBeDisabled();
+  });
+
+  it('run button should be enabled if the enableRun button is true', () => {
+    const props = getDefaultProps({ enableRun: true });
+    render(<RunQueryButtons {...props} />);
+    const runButton = screen.getByRole('button', { name: 'Run query' });
+    expect(runButton).not.toBeDisabled();
   });
 
   it('Stop query button should be disabled until run button is clicked', () => {

--- a/src/RunQueryButtons.tsx
+++ b/src/RunQueryButtons.tsx
@@ -5,7 +5,7 @@ import { DataQuery, LoadingState } from '@grafana/data';
 export interface RunQueryButtonsProps<TQuery extends DataQuery> {
   enableRun?: boolean;
   onRunQuery: () => void;
-  onCancelQuery?: (query: TQuery) => void;
+  onCancelQuery: (query: TQuery) => void;
   query: TQuery;
   state?: LoadingState;
 }
@@ -40,27 +40,25 @@ export const RunQueryButtons = <TQuery extends DataQuery>(props: RunQueryButtons
     : undefined;
 
   return (
-      <>
-        <Button
-            variant={props.enableRun ? 'primary' : 'secondary'}
-            size="sm"
-            onClick={onRunQuery}
-            icon={running && !stopping ? 'fa fa-spinner' : undefined}
-            disabled={state === LoadingState.Loading || !props.enableRun}
-        >
-          Run query
-        </Button>
-        {onCancelQuery &&
-            <Button
-                variant={running && !stopping ? 'primary' : 'secondary'}
-                size="sm"
-                disabled={!running || stopping}
-                icon={stopping ? 'fa fa-spinner' : undefined}
-                onClick={onCancelQuery}
-            >
-              Stop query
-            </Button>
-        }
-      </>
+    <>
+      <Button
+        variant={props.enableRun ? 'primary' : 'secondary'}
+        size="sm"
+        onClick={onRunQuery}
+        icon={running && !stopping ? 'fa fa-spinner' : undefined}
+        disabled={state === LoadingState.Loading || !props.enableRun}
+      >
+        Run query
+      </Button>
+      <Button
+        variant={running && !stopping ? 'primary' : 'secondary'}
+        size="sm"
+        disabled={!running || stopping}
+        icon={stopping ? 'fa fa-spinner' : undefined}
+        onClick={onCancelQuery}
+      >
+        Stop query
+      </Button>
+    </>
   );
 };


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/66277 and https://github.com/grafana/grafana/issues/66276

Removes part of the code that conditionally ran async queries. This makes it so that queries always run async