### PR TITLE
Cleanup github actions files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   check:
     name: Automated checks
@@ -9,6 +12,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup environment
         uses: actions/setup-node@v4

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -6,6 +6,9 @@ on:
       - opened
 concurrency:
   group: pr-commands-${{ github.event.number }}
+permissions:
+  contents: read
+  pull-requests: write
 jobs:
   main:
     runs-on: ubuntu-latest
@@ -16,6 +19,7 @@ jobs:
           repository: 'grafana/grafana-github-actions'
           path: ./actions
           ref: main
+          persist-credentials: false
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: 'Generate token'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,14 +11,17 @@ jobs:
     outputs:
       new_version: ${{ steps.version_check.outputs.version }}
       version_changed: ${{ steps.version_check.outputs.changed }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
+          persist-credentials: false
       # limit releases to version changes - https://github.com/EndBug/version-check
       - name: Check version changes
-        uses: EndBug/version-check@v2
+        uses: EndBug/version-check@36ff30f37c7deabe56a30caa043d127be658c425 # v2.1.5
         id: version_check
         with:
           file-url: https://unpkg.com/@grafana/async-query-data@latest/package.json
@@ -26,7 +29,10 @@ jobs:
 
       - name: Version update detected
         if: steps.version_check.outputs.changed == 'true'
-        run: 'echo "Version change found! New version: ${{ steps.version_check.outputs.version }} (${{ steps.version_check.outputs.type }})"'
+        env:
+          NEW_VERSION: ${{ steps.version_check.outputs.version }}
+          VERSION_TYPE: ${{ steps.version_check.outputs.type }}
+        run: 'echo "Version change found! New version: ${NEW_VERSION} (${VERSION_TYPE})"'
 
       - name: Setup .npmrc file for NPM registry
         if: steps.version_check.outputs.changed == 'true'
@@ -67,9 +73,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: npm-publish
     if: needs.npm-publish.outputs.version_changed == 'true'
+    env:
+      NEW_VERSION: ${{ needs.npm-publish.outputs.new_version }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Create Release Notes
         uses: actions/github-script@v7.0.1
@@ -77,6 +89,6 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             await github.request(`POST /repos/${{ github.repository }}/releases`, {
-              tag_name: "v${{needs.npm-publish.outputs.new_version }}",
+              tag_name: "v${NEW_VERSION}",
               generate_release_notes: true
             });


### PR DESCRIPTION
Fixing a bunch of issues reported by zizmor.

- Fix template injection issues.
- Pin third-party GitHub actions to specific SHAs. Excluding GitHub owned actions.
- Appropriately set permissions in workflows.
- Improve safety of checkout action.